### PR TITLE
Fix for conway's game

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = "4.5.13"
+clap = { version = "4.5.13", features = ["derive"]}
 macroquad = "0.4"
 rand = "0.8.5"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 FILE = points.txt
-ARGS = $(shell cat $(FILE))
 RNG = 30,10,100
 
 run:
-	cargo run -- -p $(ARGS)
+	cargo run -- -p < $(FILE)
 
 random:
 	cargo run -- -r $(RNG)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Implementation of Conway's Game of Life with Rust and Web Assembly
 
 
 ## Execution
-- `make run FILE=file_name` to run the game, else use `make run` to use the example `points.txt` file.
+- `make run FILE=file_name` to run the game where `file_name` contains the initial state of the game, else use `make run` to use the example `points.txt` file.
 - `cargo run -- -p 0,0:1,0:....` to pass the points yourself
 - `make random RNG=max_value,min_value,amount_of_points` to run the game with a random state, by default it goes with 30,10,1000
 - `cargo run -- -r max_value,min_value,ammount_of_points` to run the game with a random state by yourself
-
+- The different ways to run the program are, with a initial state you pass `-p` with a random initial state `-r` or just `cargo run` to run with no initial state
 
 ## Controls
 - "Enter" to pass one generation at a time

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Implementation of Conway's Game of Life with Rust and Web Assembly
 
 ## Execution
 - `make run FILE=file_name` to run the game where `file_name` contains the initial state of the game, else use `make run` to use the example `points.txt` file.
-- `cargo run -- -p 0,0:1,0:....` to pass the points yourself
+- `cargo run -- -p` to pass the points yourself with stdin
 - `make random RNG=max_value,min_value,amount_of_points` to run the game with a random state, by default it goes with 30,10,1000
 - `cargo run -- -r max_value,min_value,ammount_of_points` to run the game with a random state by yourself
-- The different ways to run the program are, with a initial state you pass `-p` with a random initial state `-r` or just `cargo run` to run with no initial state
+- The different ways to run the program are, `-p` with a initial state you pass,  `-r` with a random initial state  or just `cargo run` to run with no initial state. You can't pass `-p` and  `-r` at the same time
 
 ## Controls
 - "Enter" to pass one generation at a time

--- a/src/command_line_parser/parser.rs
+++ b/src/command_line_parser/parser.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgMatches, Command};
+use clap::{arg, ArgGroup, ArgMatches, Command};
 
 use crate::conways::point::Point;
 
@@ -19,26 +19,15 @@ pub fn parse_points_arguments(args: String) -> Result<Vec<Point>, String> {
 
 pub fn receive_command_line_arguments() -> Result<ArgMatches, String> {
     let args = Command::new(" Conway's game of life")
-        .arg(
-            Arg::new("p")
-                .short('p')
-                .long("points")
-                .value_name("Points")
-                .help("Specify the points in the format 0,0:1,0:1,1:...."),
-        )
-        .arg(
-            Arg::new("r")
-                .short('r')
-                .long("Random")
-                .value_name("Random")
-                .help("Specify the range in the format max_value,min_value,ammout_of_points"),
+        .arg(arg!(-p --points "points").required(false))
+        .arg(arg!(-r --random <RANGE> "random points").required(false))
+        .group(
+            ArgGroup::new("initial state")
+                .args(["points", "random"])
+                .required(false),
         )
         .after_help("Don't use -r and -p at the same time")
         .get_matches();
-
-    if args.contains_id("p") && args.contains_id("r") {
-        return Err("Don't use -r and -p at the same time".into());
-    }
 
     Ok(args)
 }

--- a/src/command_line_parser/parser.rs
+++ b/src/command_line_parser/parser.rs
@@ -88,35 +88,35 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_001_can_create_correct_ammount_of_random_points() {
+    fn can_create_correct_ammount_of_random_points() {
         let random_points = parse_random_arguments("100,0,5".into()).unwrap();
 
         assert_eq!(random_points.len(), 5);
     }
 
     #[test]
-    fn test_002_can_not_create_points_with_missing_arguments() {
+    fn can_not_create_points_with_missing_arguments() {
         let random_points = parse_random_arguments("100,5".into());
 
         assert!(random_points.is_err());
     }
 
     #[test]
-    fn test_003_can_not_create_points_with_wrong_type_of_arguments() {
+    fn can_not_create_points_with_wrong_type_of_arguments() {
         let random_points = parse_random_arguments("hi,100,5".into());
 
         assert!(random_points.is_err());
     }
 
     #[test]
-    fn test_004_can_not_create_points_with_min_value_bigger_than_max_value() {
+    fn can_not_create_points_with_min_value_bigger_than_max_value() {
         let random_points = parse_random_arguments("10,100,5".into());
 
         assert!(random_points.is_err());
     }
 
     #[test]
-    fn test_005_can_not_create_points_with_negative_ammout_of_points() {
+    fn can_not_create_points_with_negative_ammout_of_points() {
         let random_points = parse_random_arguments("10,100,-1".into());
 
         assert!(random_points.is_err());

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -59,7 +59,9 @@ impl ConwaysGame {
         let mut cells = HashSet::new();
 
         self.all_cells_do(|cell| {
-            if self.can_resurrect(cell) || self.can_survive(cell) {
+            if self.can_resurrect(cell) {
+                cells.insert(*cell);
+            } else if self.can_survive(cell) {
                 cells.insert(*cell);
             }
         });

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -32,7 +32,10 @@ impl ConwaysGame {
     }
 
     pub fn next_generation(&mut self) {
-        self.alive_cells = self.alive_cells();
+        let alive_cells = self.alive_cells();
+        let resurrected_cells = self.resurrected_cells();
+
+        self.alive_cells = alive_cells.union(&resurrected_cells).cloned().collect();
     }
 
     pub fn is_alive(&self, cell: Point) -> bool {
@@ -58,10 +61,19 @@ impl ConwaysGame {
     fn alive_cells(&self) -> HashSet<Point> {
         let mut cells = HashSet::new();
 
+        for cell in &self.alive_cells {
+            if self.can_survive(cell) {
+                cells.insert(*cell);
+            }
+        }
+        cells
+    }
+
+    fn resurrected_cells(&self) -> HashSet<Point> {
+        let mut cells = HashSet::new();
+
         self.all_cells_do(|cell| {
             if self.can_resurrect(cell) {
-                cells.insert(*cell);
-            } else if self.can_survive(cell) {
                 cells.insert(*cell);
             }
         });

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -124,7 +124,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_001_a_cell_without_neighbours_die_after_one_generation() {
+    fn a_cell_without_neighbours_die_after_one_generation() {
         let cells = vec![Point::new(0, 0)];
         let mut conways_game = ConwaysGame::new(cells, 10, 10).unwrap();
 
@@ -134,7 +134,7 @@ mod test {
     }
 
     #[test]
-    fn test_002_a_cell_with_two_neighbours_is_alive_after_one_generation() {
+    fn a_cell_with_two_neighbours_is_alive_after_one_generation() {
         let cells = vec![Point::new(0, 0), Point::new(0, 1), Point::new(1, 0)];
         let mut conways_game = ConwaysGame::new(cells, 10, 10).unwrap();
 
@@ -144,7 +144,7 @@ mod test {
     }
 
     #[test]
-    fn test_003_a_cell_with_three_neighbours_is_alive_after_one_generation() {
+    fn a_cell_with_three_neighbours_is_alive_after_one_generation() {
         let cells = vec![
             Point::new(0, 0),
             Point::new(0, 1),
@@ -159,7 +159,7 @@ mod test {
     }
 
     #[test]
-    fn test_004_a_cell_with_more_than_three_neighbours_dies_after_one_generation() {
+    fn a_cell_with_more_than_three_neighbours_dies_after_one_generation() {
         let cells = vec![
             Point::new(1, 1),
             Point::new(0, 0),
@@ -175,7 +175,7 @@ mod test {
     }
 
     #[test]
-    fn test_005_a_dead_cell_with_exactly_three_neighbours_resurrects_after_one_generation() {
+    fn a_dead_cell_with_exactly_three_neighbours_resurrects_after_one_generation() {
         let cells = vec![Point::new(0, 1), Point::new(1, 1), Point::new(1, 0)];
         let mut conways_game = ConwaysGame::new(cells, 10, 10).unwrap();
 
@@ -185,7 +185,7 @@ mod test {
     }
 
     #[test]
-    fn test_006_can_add_one_cell_after_a_generation_passed() {
+    fn can_add_one_cell_after_a_generation_passed() {
         let cells = vec![Point::new(0, 0)];
         let mut conways_game = ConwaysGame::new(cells, 10, 10).unwrap();
 
@@ -200,7 +200,7 @@ mod test {
     }
 
     #[test]
-    fn test_007_can_add_multiple_cells_after_a_generation_passed() {
+    fn can_add_multiple_cells_after_a_generation_passed() {
         let cells = vec![Point::new(0, 0)];
         let mut conways_game = ConwaysGame::new(cells, 10, 10).unwrap();
 
@@ -216,7 +216,7 @@ mod test {
     }
 
     #[test]
-    fn test_008_can_not_have_cells_outside_bounds() {
+    fn can_not_have_cells_outside_bounds() {
         let cells = vec![Point::new(20, 0)];
         let conways_game = ConwaysGame::new(cells, 10, 10);
 
@@ -224,7 +224,7 @@ mod test {
     }
 
     #[test]
-    fn test_009_can_not_add_cells_outside_bounds() {
+    fn an_not_add_cells_outside_bounds() {
         let cells = vec![Point::new(0, 0)];
         let mut conways_game = ConwaysGame::new(cells, 10, 10).unwrap();
         let cells = vec![Point::new(1, 0), Point::new(50, 0)];

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -32,10 +32,17 @@ impl ConwaysGame {
     }
 
     pub fn next_generation(&mut self) {
-        let alive_cells = self.alive_cells();
-        let resurrected_cells = self.resurrected_cells();
+        let mut cells = HashSet::new();
 
-        self.alive_cells = alive_cells.union(&resurrected_cells).cloned().collect();
+        self.all_cells_do(|cell| {
+            if self.can_resurrect(cell) {
+                cells.insert(*cell);
+            }
+            if self.can_survive(cell) && self.alive_cells.contains(cell) {
+                cells.insert(*cell);
+            }
+        });
+        self.alive_cells = cells;
     }
 
     pub fn is_alive(&self, cell: Point) -> bool {
@@ -56,29 +63,6 @@ impl ConwaysGame {
                 self.alive_cells.insert(*cell);
             }
         }
-    }
-
-    fn alive_cells(&self) -> HashSet<Point> {
-        let mut cells = HashSet::new();
-
-        for cell in &self.alive_cells {
-            if self.can_survive(cell) {
-                cells.insert(*cell);
-            }
-        }
-        cells
-    }
-
-    fn resurrected_cells(&self) -> HashSet<Point> {
-        let mut cells = HashSet::new();
-
-        self.all_cells_do(|cell| {
-            if self.can_resurrect(cell) {
-                cells.insert(*cell);
-            }
-        });
-
-        cells
     }
 
     fn can_resurrect(&self, cell: &Point) -> bool {

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -38,7 +38,7 @@ impl ConwaysGame {
             if self.can_resurrect(cell) {
                 cells.insert(*cell);
             }
-            if self.can_survive(cell) && self.alive_cells.contains(cell) {
+            if self.can_survive(cell) {
                 cells.insert(*cell);
             }
         });
@@ -74,7 +74,8 @@ impl ConwaysGame {
     fn can_survive(&self, cell: &Point) -> bool {
         let ammount_of_neighbours = cell.neighbours().intersection(&self.alive_cells).count();
 
-        ammount_of_neighbours == 2 || ammount_of_neighbours == 3
+        (ammount_of_neighbours == 2 || ammount_of_neighbours == 3)
+            && self.alive_cells.contains(cell)
     }
 }
 

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -35,10 +35,7 @@ impl ConwaysGame {
         let mut cells = HashSet::new();
 
         self.all_cells_do(|cell| {
-            if self.can_resurrect(cell) {
-                cells.insert(*cell);
-            }
-            if self.can_survive(cell) {
+            if self.can_resurrect(cell) || self.can_survive(cell) {
                 cells.insert(*cell);
             }
         });

--- a/src/conways/conways_game.rs
+++ b/src/conways/conways_game.rs
@@ -32,29 +32,11 @@ impl ConwaysGame {
     }
 
     pub fn next_generation(&mut self) {
-        let alive_cells = self.alive_cells();
-
-        let resurrected_cells = self.resurrected_cells();
-
-        let mut cells = HashSet::new();
-
-        for cell in alive_cells.union(&resurrected_cells) {
-            if Self::cell_is_in_range(cell, self.height, self.width) {
-                cells.insert(*cell);
-            }
-        }
-
-        self.alive_cells = cells;
+        self.alive_cells = self.alive_cells();
     }
 
     pub fn is_alive(&self, cell: Point) -> bool {
         self.alive_cells.contains(&cell)
-    }
-
-    fn alive_cells_do<F: FnMut(&Point)>(&self, mut closure: F) {
-        for cell in &self.alive_cells {
-            closure(cell);
-        }
     }
 
     pub fn all_cells_do<F: FnMut(&Point)>(&self, mut closure: F) {
@@ -66,36 +48,18 @@ impl ConwaysGame {
     }
 
     pub fn add_cells(&mut self, cells_to_add: Vec<Point>) {
-        let mut cells = HashSet::new();
-
         for cell in &cells_to_add {
             if Self::cell_is_in_range(cell, self.height, self.width) {
-                cells.insert(*cell);
+                self.alive_cells.insert(*cell);
             }
         }
-
-        self.alive_cells = self.alive_cells.union(&cells).cloned().collect();
-    }
-
-    fn resurrected_cells(&self) -> HashSet<Point> {
-        let mut cells = HashSet::new();
-
-        self.alive_cells_do(|cell| {
-            for neigbour in cell.neighbours() {
-                if self.can_resurrect(&neigbour) {
-                    cells.insert(neigbour);
-                }
-            }
-        });
-
-        cells
     }
 
     fn alive_cells(&self) -> HashSet<Point> {
         let mut cells = HashSet::new();
 
-        self.alive_cells_do(|cell| {
-            if self.can_survive(cell) {
+        self.all_cells_do(|cell| {
+            if self.can_resurrect(cell) || self.can_survive(cell) {
                 cells.insert(*cell);
             }
         });

--- a/src/conways/conways_game_view.rs
+++ b/src/conways/conways_game_view.rs
@@ -108,7 +108,7 @@ impl ConwaysGameView {
         if is_key_released(KeyCode::P) {
             self.is_passing_generations = !self.is_passing_generations;
         }
-        if is_key_released(KeyCode::Enter) {
+        if is_key_released(KeyCode::Enter) && !self.is_passing_generations {
             self.next_generation();
         }
 

--- a/src/conways/point.rs
+++ b/src/conways/point.rs
@@ -85,8 +85,29 @@ mod test {
     }
 
     #[test]
-    fn can_not_create_point_from_wrong_type() {
+    fn can_not_create_point_from_wrong_type_in_x_position() {
         let point = Point::try_from("hi,5");
+
+        assert!(point.is_err())
+    }
+
+    #[test]
+    fn can_not_create_point_from_wrong_type_in_y_position() {
+        let point = Point::try_from("5,hi");
+
+        assert!(point.is_err())
+    }
+
+    #[test]
+    fn can_not_create_point_with_extra_arguments() {
+        let point = Point::try_from("5,5,5");
+
+        assert!(point.is_err());
+    }
+
+    #[test]
+    fn can_not_create_point_with_float_arguments() {
+        let point = Point::try_from("5.0,5.4");
 
         assert!(point.is_err())
     }

--- a/src/conways/point.rs
+++ b/src/conways/point.rs
@@ -70,7 +70,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_001_can_create_a_point_from_string() {
+    fn can_create_a_point_from_string() {
         let point = Point::try_from("5,5").unwrap();
 
         assert_eq!(point.x_position, 5);
@@ -78,14 +78,14 @@ mod test {
     }
 
     #[test]
-    fn test_002_can_not_create_point_from_missing_position() {
+    fn can_not_create_point_from_missing_position() {
         let point = Point::try_from("5");
 
         assert!(point.is_err())
     }
 
     #[test]
-    fn test_003_can_not_create_point_from_wrong_type() {
+    fn can_not_create_point_from_wrong_type() {
         let point = Point::try_from("hi,5");
 
         assert!(point.is_err())

--- a/src/conways/point.rs
+++ b/src/conways/point.rs
@@ -39,22 +39,22 @@ impl Point {
 }
 
 impl TryFrom<&str> for Point {
-    type Error = String;
-    fn try_from(s: &str) -> Result<Self, String> {
+    type Error = &'static str;
+    fn try_from(s: &str) -> Result<Self, &'static str> {
         let mut positions = s.split(',');
 
         let (Some(x_position), Some(y_position), None) =
             (positions.next(), positions.next(), positions.next())
         else {
-            return Err("Bad format creating a Point, should be x_position,y_position".into());
+            return Err("Bad format creating a Point, should be x_position,y_position");
         };
 
         let Ok(x_position) = x_position.parse() else {
-            return Err("The x_position should be an integer".into());
+            return Err("The x_position should be an integer");
         };
 
         let Ok(y_position) = y_position.parse() else {
-            return Err("The y_position should be an integer".into());
+            return Err("The y_position should be an integer");
         };
 
         Ok(Self {

--- a/src/conways/point.rs
+++ b/src/conways/point.rs
@@ -49,13 +49,13 @@ impl TryFrom<&str> for Point {
             return Err("Bad format creating a Point, should be x_position,y_position");
         };
 
-        let Ok(x_position) = x_position.parse() else {
-            return Err("The x_position should be an integer");
-        };
+        let x_position = x_position
+            .parse()
+            .map_err(|_| "The x_position should be an integer")?;
 
-        let Ok(y_position) = y_position.parse() else {
-            return Err("The y_position should be an integer");
-        };
+        let y_position = y_position
+            .parse()
+            .map_err(|_| "The y_position should be an integer")?;
 
         Ok(Self {
             x_position,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,12 @@ use conways::{
 
 #[macroquad::main("Conway's Game")]
 async fn main() -> Result<(), String> {
-    let mut points_input = String::new();
-
     let args = receive_command_line_arguments()?;
 
     let mut cells = Vec::new();
 
     if args.get_flag("points") {
+        let mut points_input = String::new();
         let stdin = stdin();
         stdin
             .read_line(&mut points_input)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::stdin;
+
 use conways::{
     command_line_parser::parser::{
         parse_points_arguments, parse_random_arguments, receive_command_line_arguments,
@@ -11,15 +13,21 @@ use conways::{
 
 #[macroquad::main("Conway's Game")]
 async fn main() -> Result<(), String> {
+    let mut points_input = String::new();
+
     let args = receive_command_line_arguments()?;
 
     let mut cells = Vec::new();
 
-    if let Some(points) = args.get_one::<String>("p") {
-        cells = parse_points_arguments(points.clone())?;
+    if args.get_flag("points") {
+        let stdin = stdin();
+        stdin
+            .read_line(&mut points_input)
+            .map_err(|error| error.to_string())?;
+        cells = parse_points_arguments(points_input.trim().to_string())?;
     }
 
-    if let Some(random) = args.get_one::<String>("r") {
+    if let Some(random) = args.get_one::<String>("random") {
         cells = parse_random_arguments(random.clone())?;
     }
 


### PR DESCRIPTION
## Summary
This PR fix some problems and over-complex functions in the `ConwaysGame` struct, also adding some more tests for creating `Points` with strings, and a new way to run the game

## Changes
- changed `ConwaysGame` function with a simpler way for passing generations, reducing the needs of closures and set utilities
- added new tests to the creation of `Points`, cases like a string with more elements or using floats
- updated `parser.rs` to take more advantage of `clap` arguments group, and accepts parameters from stdin instead of command line arguments.

### Minor changes
- changed the name of all tests, deleting the test_number prefix, but not the logic of them, can be ignored.
- updated the README with the new way of passing arguments and better explained the meaning of the arguments
- changed the error handling of the creation of points from a `if let` and returning a `String` to a `.map_err()?`, returning a `&static str`, the logic is the same.
- can only pass generations by hand if the game is paused